### PR TITLE
차트 페이지 타이틀 추가, 각 차트의 타이틀을 Card 컴포넌트 내부로 이동

### DIFF
--- a/src/components/chart/Chart.js
+++ b/src/components/chart/Chart.js
@@ -68,15 +68,15 @@ function Chart({
 
   return (
     <Wrapper>
-      <Headr>
-        <Title>{title}</Title>
-        {!isStacked ? (
-          <ToggleButton onClick={handleClick}>변경</ToggleButton>
-        ) : (
-          ''
-        )}
-      </Headr>
       <Card>
+        <Headr>
+          <Title>{title}</Title>
+          {!isStacked ? (
+            <ToggleButton onClick={handleClick}>변경</ToggleButton>
+          ) : (
+            ''
+          )}
+        </Headr>
         <CanvasWrapper minHeight={minHeight} minWidth={minWidth}>
           {chart}
         </CanvasWrapper>

--- a/src/components/chart/ChartTitle.js
+++ b/src/components/chart/ChartTitle.js
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  margin-bottom: 2rem;
+`;
+
+const Title = styled.h1`
+  text-align: center;
+  margin-top: 0;
+`;
+const Descriptions = styled.div`
+  text-align: center;
+`;
+
+function ChartTitle() {
+  return (
+    <Wrapper>
+      <Title>🎉 설문 조사 결과</Title>
+      <Descriptions>다른 사람들은 어떤 선택했을까요?</Descriptions>
+    </Wrapper>
+  );
+}
+
+export default ChartTitle;

--- a/src/pages/ChartPage.js
+++ b/src/pages/ChartPage.js
@@ -3,6 +3,7 @@ import Chart from '../components/chart/Chart';
 import { getQuestions } from '../util/firebaseApi';
 import staticData from '../dummy/data';
 import Loading from '../components/chart/Loading';
+import ChartTitle from '../components/chart/ChartTitle';
 
 function ChartPage() {
   const [questions, setQuestions] = useState([]);
@@ -32,6 +33,7 @@ function ChartPage() {
 
   return (
     <>
+      <ChartTitle />
       {questions.map(chart => (
         <Chart
           isStacked={false}


### PR DESCRIPTION
## 기능
- 각각 차트의 질문 타이틀을 차트 내부로 이동
- 차트 페이지 상단에 메시지 추가
![image](https://user-images.githubusercontent.com/44540726/216800522-e2e17e47-ff9c-4d3c-8cee-bb72d11ff55c.png)

