### PR TITLE
[bug fix] 차트 제목과 버튼 겹치는 현상 해결 - #31

### DIFF
--- a/src/components/chart/Chart.js
+++ b/src/components/chart/Chart.js
@@ -8,7 +8,7 @@ import StackedBarChart from './StackedBarChart';
 
 /* Wrapper */
 const Wrapper = styled.div`
-  padding: 1rem;
+  padding: 1rem 0;
 `;
 
 const Headr = styled.div`

--- a/src/components/chart/Chart.js
+++ b/src/components/chart/Chart.js
@@ -8,11 +8,12 @@ import StackedBarChart from './StackedBarChart';
 
 /* Wrapper */
 const Wrapper = styled.div`
-  margin-bottom: 2rem;
+  padding: 1rem;
 `;
 
 const Headr = styled.div`
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   position: relative;
@@ -20,16 +21,14 @@ const Headr = styled.div`
 
 /* Title */
 const Title = styled.h3`
+  margin: 0;
   text-align: center;
   flex: 1 1 0;
 `;
 
 const ToggleButton = styled(Button)`
   justify-items: flex-end;
-  position: absolute;
-  font-size: 12px;
-  right: 5px;
-  /* bottom: 5px; */
+  align-self: end;
 `;
 
 /* Canvas Wrapper */
@@ -72,7 +71,9 @@ function Chart({
         <Headr>
           <Title>{title}</Title>
           {!isStacked ? (
-            <ToggleButton onClick={handleClick}>변경</ToggleButton>
+            <ToggleButton size="sm" onClick={handleClick}>
+              {toggle ? 'chart' : 'bar'}
+            </ToggleButton>
           ) : (
             ''
           )}


### PR DESCRIPTION
이슈 링크 : #31 
제목 왼쪽 하단으로 버튼 위치 변경

<img width="388" alt="image" src="https://user-images.githubusercontent.com/19286161/216813182-5d444326-619c-49a8-a673-f880acb0c1ae.png">
