### PR TITLE
🐛 IOS 모바일 브러우저 스크롤현상 수정 - bunniesDev#35

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { useEffect } from 'react';
 
 import GlobalStyles from './GlobalStyles';
 import ChartPage from './pages/ChartPage';
@@ -8,6 +9,14 @@ import SurveyPage from './pages/SurveyPage';
 import MainLayout from './components/layouts/MainLayout';
 
 function App() {
+  function setScreenSize() {
+    const vh = window.innerHeight * 0.01;
+    document.documentElement.style.setProperty('--vh', `${vh}px`);
+  }
+  useEffect(() => {
+    setScreenSize();
+  });
+
   return (
     <>
       <BrowserRouter>

--- a/src/GlobalStyles.js
+++ b/src/GlobalStyles.js
@@ -2,6 +2,9 @@ import { createGlobalStyle } from 'styled-components';
 import CookieRunRegular from './assets/fonts/CookieRun-Regular.woff2';
 
 const GlobalStyles = createGlobalStyle` 
+  :root {
+       --vh: 100%;
+   }
 
   @font-face {
     font-family: 'CookieRunRegular';

--- a/src/components/chart/Loading.js
+++ b/src/components/chart/Loading.js
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
 
 const Container = styled.div`
-  height: 100vh;
+  height: calc(100vh - 4.5rem);
+  height: calc(var(--vh, 1vh) * 100 - 4.5rem);
   width: 100%;
   display: flex;
   justify-content: center;

--- a/src/components/layouts/MainLayout.js
+++ b/src/components/layouts/MainLayout.js
@@ -13,7 +13,8 @@ const StyledMainLayout = styled(NoneLayout)``;
 
 const StyledArticle = styled.article`
   padding: 0;
-  height: calc(100vh - 4.5rem);
+  height: calc(100vh - 4.5rem); /* fallback */
+  height: calc(var(--vh, 1vh) * 100 - 4.5rem);
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/src/components/layouts/NoneLayout.js
+++ b/src/components/layouts/NoneLayout.js
@@ -5,7 +5,9 @@ const StyledNoneLayout = styled.main`
   max-width: 640px;
   margin: 0 auto;
   background-color: #fff;
-  height: 100vh;
+  height: 100vh; // 혹시나 Custom Property 지원 안하는 브라우저를 위한 복귀점
+  height: calc(var(--vh, 1vh) * 100);
+
   box-shadow: 0 0 1rem rgba(0, 0, 0, 0.1);
 `;
 

--- a/src/pages/IntroPage.js
+++ b/src/pages/IntroPage.js
@@ -16,6 +16,8 @@ const StyledArticle = styled.article`
   justify-content: space-between;
   padding: 3rem 1.5rem;
   height: 100vh;
+  height: calc(var(--vh, 1vh) * 100);
+
   overflow-y: auto;
   &.intro-main {
     background-image: url(${IntroBg});


### PR DESCRIPTION
### IOS  모바일 브러우저에서 스크롤 생김 현상 수정
이슈번호: #35 
- 원인 : IOS 모바일에서 주소창 등을 포함한 크기를 100vh로 계산하여 스크롤이 생기는 현상
- 수정 :  렌더링시 `--vh` css 변수에  **[innerHeight(주소창 등을 뺀 나머지 크기)](https://developer.mozilla.org/en-US/docs/Web/API/Window/innerHeight)** 를 할당하도록 수정
  - app.js
  ```jsx
  const vh = window.innerHeight * 0.01;
  document.documentElement.style.setProperty("--vh", `${vh}px`);
  ```

  - css 수정
  ```css
  height: 100vh // 하기의 custom 프로퍼티가 인식 안되는 경우를 대비하여 남겨둠
  height: calc(var(--vh, 1vh) * 100)
  ```
- 참고 : [React 모바일 웹 앱 100vh 실제 화면 크기로 맞추기](https://velog.io/@eunddodi/React-%EB%AA%A8%EB%B0%94%EC%9D%BC-%EC%9B%B9-%EC%95%B1-100vh-%EC%8B%A4%EC%A0%9C-%ED%99%94%EB%A9%B4-%ED%81%AC%EA%B8%B0%EB%A1%9C-%EB%A7%9E%EC%B6%94%EA%B8%B0)