### PR TITLE
🐛 PC 환경에서 크기 고정 이슈- bunniesDev#35

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,8 +13,13 @@ function App() {
     const vh = window.innerHeight * 0.01;
     document.documentElement.style.setProperty('--vh', `${vh}px`);
   }
+
   useEffect(() => {
-    setScreenSize();
+    const isMobile = /Mobi/i.test(window.navigator.userAgent);
+
+    if (isMobile) {
+      setScreenSize();
+    }
   });
 
   return (

--- a/src/GlobalStyles.js
+++ b/src/GlobalStyles.js
@@ -2,10 +2,6 @@ import { createGlobalStyle } from 'styled-components';
 import CookieRunRegular from './assets/fonts/CookieRun-Regular.woff2';
 
 const GlobalStyles = createGlobalStyle` 
-  :root {
-       --vh: 100%;
-   }
-
   @font-face {
     font-family: 'CookieRunRegular';
     font-style: normal;


### PR DESCRIPTION
관련 이슈: #35 

- 원인 : 접속 당시 innerHeight px 크기로 지정하여, 브라우저 사이즈를 조절가능한 PC환경에서 브라우저 사이즈 변경하여도 높이가 고정되는 이슈 발생
- 수정 : 모바일 기기의 경우만 적용하도록 수정
   - app.js 수정
   ```jsx
    const isMobile = /Mobi/i.test(window.navigator.userAgent);

    // 모바일인 경우만 innerHeight로 스크린 재조정
    if (isMobile) {
      setScreenSize();
    }
   ``` 